### PR TITLE
Added onChanged notifier

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,6 +14,9 @@ class _MyAppState extends State<MyApp> {
   var _signatureCanvas = Signature(
     height: 300,
     backgroundColor: Colors.lightBlueAccent,
+    onChanged: (points) {
+      print(points);
+    },
   );
 
   @override

--- a/lib/signature.dart
+++ b/lib/signature.dart
@@ -74,8 +74,8 @@ class SignatureState extends State<Signature> {
   //CLEAR POINTS AND REBUILD. CANVAS WILL BE BLANK
   void clear() {
     setState(() => _points.clear());
-    //NOTIFY OF CHANGE AFTER MOVEMENT IS DONE
-    widget.onChanged(_points);
+    //NOTIFY OF CHANGE AFTER SIGNATURE PAD CLEARED
+    if(widget.onChanged != null) widget.onChanged(_points);
   }
 
   //CHECK IF SIGNATURE IS EMPTY
@@ -107,7 +107,7 @@ class SignatureState extends State<Signature> {
         onPointerUp: (event){
           _addPoint(event, PointType.tap);
           //NOTIFY OF CHANGE AFTER MOVEMENT IS DONE
-          widget.onChanged(_points);
+          if(widget.onChanged != null) widget.onChanged(_points);
         },
         onPointerMove: (event) => _addPoint(event, PointType.move),
         child: RepaintBoundary(

--- a/lib/signature.dart
+++ b/lib/signature.dart
@@ -14,6 +14,7 @@ class Signature extends StatefulWidget {
     this.backgroundColor = Colors.grey,
     this.penColor = Colors.black,
     this.penStrokeWidth = 3.0,
+    this.onChanged,
   });
 
   final List<Point> points;
@@ -23,6 +24,7 @@ class Signature extends StatefulWidget {
   final Color penColor;
   final double penStrokeWidth;
   final GlobalKey<SignatureState> key = GlobalKey<SignatureState>();
+  final ValueChanged<List<Point>> onChanged;
 
   ///Returns collection of 2D points that represents current signature
   List<Point> exportPoints() {
@@ -72,6 +74,8 @@ class SignatureState extends State<Signature> {
   //CLEAR POINTS AND REBUILD. CANVAS WILL BE BLANK
   void clear() {
     setState(() => _points.clear());
+    //NOTIFY OF CHANGE AFTER MOVEMENT IS DONE
+    widget.onChanged(_points);
   }
 
   //CHECK IF SIGNATURE IS EMPTY
@@ -100,7 +104,11 @@ class SignatureState extends State<Signature> {
       ),
       child: Listener(
         onPointerDown: (event) => _addPoint(event, PointType.tap),
-        onPointerUp: (event) => _addPoint(event, PointType.tap),
+        onPointerUp: (event){
+          _addPoint(event, PointType.tap);
+          //NOTIFY OF CHANGE AFTER MOVEMENT IS DONE
+          widget.onChanged(_points);
+        },
         onPointerMove: (event) => _addPoint(event, PointType.move),
         child: RepaintBoundary(
           child: CustomPaint(


### PR DESCRIPTION
Hi guys,
I propose adding an `onChanged` notifier function of type `ValueChanged<List<Point>>` that will fire when the signature pad is cleared and `onPointerUp`.

Possible use for this would be to enable one to embed the signature pad inside a `FormField` in a flutter `Form`. I would especially like to use this awesome plugin in my [flutter_form_builder package](https://pub.dartlang.org/packages/flutter_form_builder/versions/3.0.0-beta.2) to allow having a signature pad inside a form 