### PR TITLE
Exported width cannot be smaller than actual width

### DIFF
--- a/lib/signature.dart
+++ b/lib/signature.dart
@@ -437,13 +437,13 @@ class SignatureController extends ValueNotifier<List<Point>> {
 
   /// convert canvas to dart:ui [Image] and then to PNG represented in [Uint8List]
   /// Will return `null` if there are no points.
-  Future<Uint8List?> toPngBytes() async {
+  Future<Uint8List?> toPngBytes([int height = 500, int width = 400]) async {
     if (kIsWeb) {
       return _toPngBytesForWeb();
     }
 
     //WIDTH AND HEIGHT IS OPTIONAL. IMAGE WILL BE CENTERED
-    final ui.Image? image = await toImage(height: 500, width: 400);
+    final ui.Image? image = await toImage(height: height, width: width);
 
     if (image == null) {
       return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: signature
 description: A Flutter plugin providing performance optimized signature canvas with ability to set custom style, boundaries and initial state.
-version: 5.2.1
+version: 5.2.1+1
 homepage: https://github.com/4Q-s-r-o/signature
 
 environment:


### PR DESCRIPTION
This line:

`final ui.Image? image = await toImage(height: 500, width: 400);`

Height and width has a fixed value, it causing the issue:

`Failed assertion: line 413 pos 9: '((width ?? defaultWidth!) - defaultWidth!) >= 0.0': Exported width cannot be smaller than actual width`

When I try:  `_controller.toPngBytes();`

Because my `Signature` widget has the my screen size, and that has:
Width: 375px
Height: 812px

How 375 is smaller then the default value `400`, I cannot export, my commit fix that making possible change this value by method parameters.

This occurs because I am using the landscape mode in the application.