### PR TITLE
Expose StrokeCap and StrokeJoin to SignatureController

### DIFF
--- a/lib/signature.dart
+++ b/lib/signature.dart
@@ -207,7 +207,9 @@ class _SignaturePainter extends CustomPainter {
         super(repaint: _controller) {
     _penStyle
       ..color = penColor != null ? penColor : _controller.penColor
-      ..strokeWidth = _controller.penStrokeWidth;
+      ..strokeWidth = _controller.penStrokeWidth
+      ..strokeCap = _controller.strokeCap
+      ..strokeJoin = _controller.strokeJoin;
   }
 
   final SignatureController _controller;
@@ -249,6 +251,8 @@ class SignatureController extends ValueNotifier<List<Point>> {
   SignatureController({
     List<Point>? points,
     this.penColor = Colors.black,
+    this.strokeCap = StrokeCap.butt,
+    this.strokeJoin = StrokeJoin.miter,
     this.penStrokeWidth = 3.0,
     this.exportBackgroundColor,
     this.exportPenColor,
@@ -262,6 +266,12 @@ class SignatureController extends ValueNotifier<List<Point>> {
 
   /// boldness of a signature line
   final double penStrokeWidth;
+
+  /// shape of line ends
+  final StrokeCap strokeCap;
+
+  /// shape of line joins
+  final StrokeJoin strokeJoin;
 
   /// background color to be used in exported png image
   final Color? exportBackgroundColor;


### PR DESCRIPTION
Adding these options to the SignatureController allows it to have a bigger variety of drawing styles when using the package. The default values reflect the ones used before, so the change should be fully backwards compatible