### PR TITLE
add bool getters for checking if can undo/redo an action

### DIFF
--- a/lib/signature.dart
+++ b/lib/signature.dart
@@ -352,6 +352,12 @@ class SignatureController extends ValueNotifier<List<Point>> {
   /// check if canvas is not empty (opposite of isEmpty method for convenience)
   bool get isNotEmpty => value.isNotEmpty;
 
+  /// check if there is any action to undo
+  bool get canUndo => _latestActions.isNotEmpty;
+
+  /// check if there is any action to redo
+  bool get canRedo => _revertedActions.isNotEmpty;
+
   /// The biggest x value for all points.
   /// Will return `null` if there are no points.
   double? get maxXValue =>


### PR DESCRIPTION
# Changes

Expose `canUndo` and `canRedo` bool getters in SignatureController.

# Why?

When providing undo/redo buttons, I'd like to be able to disable a button if there aren't any actions to undo/redo.

Demo use case (notice undo/redo buttons are always enabled because this functionality wasn't exposed before):
<img width="316" alt="image" src="https://github.com/user-attachments/assets/79c71718-c406-4d86-8274-cb9d59cd855b">
